### PR TITLE
Fix node config path on Kupo

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -79,7 +79,7 @@ services:
       - --node-socket
       - /ipc/node.socket
       - --node-config
-      - /config/preview/cardano-node/config.json
+      - /config/config.json
       - --host
       - 0.0.0.0
       - --workdir


### PR DESCRIPTION
This fixes an error where Kupo was crashing upon running `docker-compose up`